### PR TITLE
Initial implementation of xml serialize and deserialize jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 env:
   global:
-    - CC_TEST_REPORTER_ID=2d57d597269e2cb04a63d0a7262927cf811abb7ab528da7de681943b212b4134
+    - CC_TEST_REPORTER_ID=fa3b91a072547e91492ea97e69498eb5cfc472daec7d24827549f515a3bb929e
 language: ruby
 rvm:
   # Build on the latest stable of all supported Rubies (https://www.ruby-lang.org/en/downloads/):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,3 @@
-# 0.1.0 (TBD)
+# 0.1.0 (December 29th, 2020)
 
 Initial Version

--- a/README.md
+++ b/README.md
@@ -1,3 +1,89 @@
 # Markup Fuel
 
-Under Construction.
+[![Gem Version](https://badge.fury.io/rb/markup_fuel.svg)](https://badge.fury.io/rb/markup_fuel) [![Build Status](https://travis-ci.com/bluemarblepayroll/markup_fuel.svg?branch=master)](https://travis-ci.com/bluemarblepayroll/markup_fuel) [![Maintainability](https://api.codeclimate.com/v1/badges/e38efa993c8292a45a99/maintainability)](https://codeclimate.com/github/bluemarblepayroll/markup_fuel/maintainability) [![Test Coverage](https://api.codeclimate.com/v1/badges/e38efa993c8292a45a99/test_coverage)](https://codeclimate.com/github/bluemarblepayroll/markup_fuel/test_coverage) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+This library is a plugin for [Burner](https://github.com/bluemarblepayroll/burner).  It adds jobs focused around XML processing such as reading and writing XML documents.  XML can get very non-trivial quickly, but this library aims at implementing only what is identified as necessary for XML processing.  Pull requests are welcomed to add more additional functionality.
+
+## Installation
+
+To install through Rubygems:
+
+````bash
+gem install markup_fuel
+````
+
+You can also add this to your Gemfile:
+
+````bash
+bundle add markup_fuel
+````
+## Jobs
+
+Refer to the [Burner](https://github.com/bluemarblepayroll/burner) library for more specific information on how Burner works.  This section will just focus on what this library directly adds.
+
+* **markup_fuel/deserialize/xlsx** [register, sheet_mappings]: Take the register, parse it as a Microsoft Excel Open XML spreadsheet and store the sheet data in the specified sheet_mappings' registers.  Each sheet mapping specifies which sheet to read and where to place the parsed data.  If no sheet mappings are specified then the default sheet will be parsed and placed in the register.
+* **markup_fuel/serialize/xlsx** [register, sheet_mappings]: Create a Microsoft Excel Open XML workbook and write all specified register data into their respective sheets.  The sheet_mappings will specify which sheets get data and from which register.
+
+## Examples
+
+### Parsing (de-serializing) an XML Document
+
+TODO
+
+### Writing (serializing) an XML Document
+
+TODO
+
+## Contributing
+
+### Development Environment Configuration
+
+Basic steps to take to get this repository compiling:
+
+1. Install [Ruby](https://www.ruby-lang.org/en/documentation/installation/) (check markup_fuel.gemspec for versions supported)
+2. Install bundler (gem install bundler)
+3. Clone the repository (git clone git@github.com:bluemarblepayroll/markup_fuel.git)
+4. Navigate to the root folder (cd markup_fuel)
+5. Install dependencies (bundle)
+
+### Running Tests
+
+To execute the test suite run:
+
+````bash
+bundle exec rspec spec --format documentation
+````
+
+Alternatively, you can have Guard watch for changes:
+
+````bash
+bundle exec guard
+````
+
+Also, do not forget to run Rubocop:
+
+````bash
+bundle exec rubocop
+````
+
+### Publishing
+
+Note: ensure you have proper authorization before trying to publish new versions.
+
+After code changes have successfully gone through the Pull Request review process then the following steps should be followed for publishing new versions:
+
+1. Merge Pull Request into master
+2. Update `lib/markup_fuel/version.rb` using [semantic versioning](https://semver.org/)
+3. Install dependencies: `bundle`
+4. Update `CHANGELOG.md` with release notes
+5. Commit & push master to remote and ensure CI builds master successfully
+6. Run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+
+## Code of Conduct
+
+Everyone interacting in this codebase, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/bluemarblepayroll/markup_fuel/blob/master/CODE_OF_CONDUCT.md).
+
+## License
+
+This project is MIT Licensed.
+

--- a/lib/markup_fuel.rb
+++ b/lib/markup_fuel.rb
@@ -7,9 +7,7 @@
 # LICENSE file in the root directory of this source tree.
 #
 
-require 'acts_as_hashable'
 require 'burner'
+require 'xmlsimple'
 
-# Stub out the top-level namespace
-module MarkupFuel
-end
+require_relative 'markup_fuel/library'

--- a/lib/markup_fuel/library.rb
+++ b/lib/markup_fuel/library.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+#
+# Copyright (c) 2020-present, Blue Marble Payroll, LLC
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+require_relative 'library/deserialize/xml'
+require_relative 'library/serialize/xml'
+
+module Burner
+  # Open up the Burner::Jobs class and register our jobs.
+  class Jobs
+    register 'markup_fuel/deserialize/xlsx', MarkupFuel::Library::Deserialize::Xml
+    register 'markup_fuel/serialize/xlsx',   MarkupFuel::Library::Serialize::Xml
+  end
+end

--- a/lib/markup_fuel/library.rb
+++ b/lib/markup_fuel/library.rb
@@ -13,7 +13,7 @@ require_relative 'library/serialize/xml'
 module Burner
   # Open up the Burner::Jobs class and register our jobs.
   class Jobs
-    register 'markup_fuel/deserialize/xlsx', MarkupFuel::Library::Deserialize::Xml
-    register 'markup_fuel/serialize/xlsx',   MarkupFuel::Library::Serialize::Xml
+    register 'markup_fuel/deserialize/xml', MarkupFuel::Library::Deserialize::Xml
+    register 'markup_fuel/serialize/xml',   MarkupFuel::Library::Serialize::Xml
   end
 end

--- a/lib/markup_fuel/library/deserialize/xml.rb
+++ b/lib/markup_fuel/library/deserialize/xml.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+#
+# Copyright (c) 2020-present, Blue Marble Payroll, LLC
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+module MarkupFuel
+  module Library
+    module Deserialize
+      # This job works on a single register, reads its value, and de-serializes it using
+      # the XmlSimple gem.  There is some nice documentation that ships with the gem
+      # located here: https://github.com/maik/xml-simple/tree/master/docs.
+      # More or less, this is just a Burner::Job wrapper around the XmlSimple#xml_in API.
+      #
+      # Expected Payload[register] input: string of XML.
+      # Payload[register] output: Ruby object representation of the XML.
+      class Xml < Burner::JobWithRegister
+        FORCE_ARRAY_KEY = 'ForceArray'
+
+        attr_reader :options
+
+        def initialize(
+          name:,
+          force_array: false,
+          register: Burner::DEFAULT_REGISTER
+        )
+          super(name: name, register: register)
+
+          @options = make_options(force_array)
+
+          freeze
+        end
+
+        def perform(_output, payload)
+          value = payload[register]
+
+          if value.to_s.empty?
+            payload[register] = nil
+            return
+          end
+
+          payload[register] = XmlSimple.xml_in(payload[register], options)
+        end
+
+        private
+
+        def make_options(force_array)
+          { FORCE_ARRAY_KEY => force_array }
+        end
+      end
+    end
+  end
+end

--- a/lib/markup_fuel/library/serialize/xml.rb
+++ b/lib/markup_fuel/library/serialize/xml.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+#
+# Copyright (c) 2020-present, Blue Marble Payroll, LLC
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+module MarkupFuel
+  module Library
+    module Serialize
+      # This job works on a single register, reads its value, and serializes it using
+      # the XmlSimple gem.  There is some nice documentation that ships with the gem
+      # located here: https://github.com/maik/xml-simple/tree/master/docs.
+      # More or less, this is just a Burner::Job wrapper around the XmlSimple#xml_out API.
+      #
+      # Expected Payload[register] input: Ruby object modeling.
+      # Payload[register] output: XML representation of the Ruby object modeling as a string.
+      class Xml < Burner::JobWithRegister
+        NO_ATTR_KEY   = 'NoAttr'
+        ROOT_NAME_KEY = 'RootName'
+
+        attr_reader :options
+
+        def initialize(
+          name:,
+          no_attributes: true,
+          register: Burner::DEFAULT_REGISTER,
+          root_name: nil
+        )
+          super(name: name, register: register)
+
+          @options = make_options(no_attributes, root_name)
+
+          freeze
+        end
+
+        def perform(_output, payload)
+          payload[register] = XmlSimple.xml_out(payload[register] || {}, options)
+        end
+
+        def make_options(no_attributes, root_name)
+          { NO_ATTR_KEY => no_attributes }.tap do |opts|
+            opts[ROOT_NAME_KEY] = root_name unless root_name.to_s.empty?
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/markup_fuel/version.rb
+++ b/lib/markup_fuel/version.rb
@@ -8,5 +8,5 @@
 #
 
 module MarkupFuel
-  VERSION = '0.0.0'
+  VERSION = '0.1.0-alpha'
 end

--- a/lib/markup_fuel/version.rb
+++ b/lib/markup_fuel/version.rb
@@ -8,5 +8,5 @@
 #
 
 module MarkupFuel
-  VERSION = '0.1.0-alpha'
+  VERSION = '0.1.0'
 end

--- a/markup_fuel.gemspec
+++ b/markup_fuel.gemspec
@@ -5,10 +5,10 @@ require './lib/markup_fuel/version'
 Gem::Specification.new do |s|
   s.name        = 'markup_fuel'
   s.version     = MarkupFuel::VERSION
-  s.summary     = 'TBD'
+  s.summary     = 'XML jobs for Burner'
 
   s.description = <<-DESCRIPTION
-   TBD
+    This library adds XML-centric jobs to the Burner library.  Burner does not ship with XML jobs out of the box.
   DESCRIPTION
 
   s.authors     = ['Matthew Ruggio']

--- a/markup_fuel.gemspec
+++ b/markup_fuel.gemspec
@@ -28,8 +28,8 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.5'
 
-  s.add_dependency('acts_as_hashable', '~>1.2')
   s.add_dependency('burner', '~>1.0')
+  s.add_dependency('xml-simple', '~>1.1')
 
   s.add_development_dependency('guard-rspec', '~>4.7')
   s.add_development_dependency('pry', '~>0')

--- a/spec/fixtures/patients.xml
+++ b/spec/fixtures/patients.xml
@@ -1,0 +1,16 @@
+<patients>
+  <patient>
+    <id>1</id>
+    <demographics>
+      <first>Bozo</first>
+      <last>Clown</last>
+    </demographics>
+  </patient>
+  <patient>
+    <id>2</id>
+    <demographics>
+      <first>Frank</first>
+      <last>Rizzo</last>
+    </demographics>
+  </patient>
+</patients>

--- a/spec/fixtures/patients_with_attrs.xml
+++ b/spec/fixtures/patients_with_attrs.xml
@@ -1,0 +1,14 @@
+<patients>
+  <patient id="1">
+    <demographics>
+      <first>Bozo</first>
+      <last>Clown</last>
+    </demographics>
+  </patient>
+  <patient id="2">
+    <demographics>
+      <first>Frank</first>
+      <last>Rizzo</last>
+    </demographics>
+  </patient>
+</patients>

--- a/spec/markup_fuel/library/deserialize/xml_spec.rb
+++ b/spec/markup_fuel/library/deserialize/xml_spec.rb
@@ -53,6 +53,37 @@ describe MarkupFuel::Library::Deserialize::Xml do
       expect(actual).to eq(expected)
     end
 
+    context 'when content has attributes' do
+      let(:path) { File.join('spec', 'fixtures', 'patients_with_attrs.xml') }
+
+      specify 'payload register has deserialized data' do
+        subject.perform(output, payload)
+
+        actual = payload[register]
+
+        expected = {
+          'patient' => [
+            {
+              'demographics' => {
+                'first' => 'Bozo',
+                'last' => 'Clown'
+              },
+              'id' => '1'
+            },
+            {
+              'demographics' => {
+                'first' => 'Frank',
+                'last' => 'Rizzo'
+              },
+              'id' => '2'
+            }
+          ]
+        }
+
+        expect(actual).to eq(expected)
+      end
+    end
+
     context 'when content is nil' do
       let(:contents) { nil }
 

--- a/spec/markup_fuel/library/deserialize/xml_spec.rb
+++ b/spec/markup_fuel/library/deserialize/xml_spec.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+#
+# Copyright (c) 2020-present, Blue Marble Payroll, LLC
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+require 'spec_helper'
+
+describe MarkupFuel::Library::Deserialize::Xml do
+  let(:output)      { Burner::Output.new(outs: [StringIO.new]) }
+  let(:register)    { 'register_a' }
+  let(:path)        { File.join('spec', 'fixtures', 'patients.xml') }
+  let(:contents)    { File.open(path, &:read) }
+  let(:payload)     { Burner::Payload.new(registers: { register => contents }) }
+  let(:force_array) { false }
+
+  subject do
+    described_class.make(
+      force_array: force_array,
+      name: 'test_job',
+      register: register
+    )
+  end
+
+  describe '#perform' do
+    specify 'payload register has deserialized data' do
+      subject.perform(output, payload)
+
+      actual = payload[register]
+
+      expected = {
+        'patient' => [
+          {
+            'demographics' => {
+              'first' => 'Bozo',
+              'last' => 'Clown'
+            },
+            'id' => '1'
+          },
+          {
+            'demographics' => {
+              'first' => 'Frank',
+              'last' => 'Rizzo'
+            },
+            'id' => '2'
+          }
+        ]
+      }
+
+      expect(actual).to eq(expected)
+    end
+
+    context 'when content is nil' do
+      let(:contents) { nil }
+
+      specify 'payload register is set to nil' do
+        subject.perform(output, payload)
+
+        actual   = payload[register]
+        expected = nil
+
+        expect(actual).to eq(expected)
+      end
+    end
+
+    context 'when content is a blank string' do
+      let(:contents) { '' }
+
+      specify 'payload register is set to nil' do
+        subject.perform(output, payload)
+
+        actual   = payload[register]
+        expected = nil
+
+        expect(actual).to eq(expected)
+      end
+    end
+
+    context 'when forcing arrays' do
+      let(:force_array) { true }
+
+      specify 'payload register key values are arrays' do
+        subject.perform(output, payload)
+
+        actual   = payload[register]
+        expected = {
+          'patient' => [
+            {
+              'demographics' => [
+                {
+                  'first' => ['Bozo'],
+                  'last' => ['Clown']
+                }
+              ],
+              'id' => ['1']
+            },
+            {
+              'demographics' => [
+                {
+                  'first' => ['Frank'],
+                  'last' => ['Rizzo']
+                }
+              ],
+              'id' => ['2']
+            }
+          ]
+        }
+
+        expect(actual).to eq(expected)
+      end
+    end
+  end
+end

--- a/spec/markup_fuel/library/deserialize/xml_spec.rb
+++ b/spec/markup_fuel/library/deserialize/xml_spec.rb
@@ -113,4 +113,68 @@ describe MarkupFuel::Library::Deserialize::Xml do
       end
     end
   end
+
+  describe 'README examples' do
+    specify 'the simple parsing example works' do
+      pipeline = {
+        jobs: [
+          {
+            name: 'read',
+            type: 'b/value/static',
+            register: 'patients',
+            value: <<~XML
+              <patients>
+                <patient>
+                  <id>1</id>
+                  <demographics>
+                    <first>Bozo</first>
+                    <last>Clown</last>
+                  </demographics>
+                </patient>
+                <patient>
+                  <id>2</id>
+                  <demographics>
+                    <first>Frank</first>
+                    <last>Rizzo</last>
+                  </demographics>
+                </patient>
+              </patients>
+            XML
+          },
+          {
+            name: 'parse',
+            register: 'patients',
+            type: 'markup_fuel/deserialize/xml'
+          }
+        ]
+      }
+
+      payload = Burner::Payload.new
+
+      Burner::Pipeline.make(pipeline).execute(output: output, payload: payload)
+
+      actual = payload['patients']
+
+      expected = {
+        'patient' => [
+          {
+            'demographics' => {
+              'first' => 'Bozo',
+              'last' => 'Clown'
+            },
+            'id' => '1'
+          },
+          {
+            'demographics' => {
+              'first' => 'Frank',
+              'last' => 'Rizzo'
+            },
+            'id' => '2'
+          }
+        ]
+      }
+
+      expect(actual).to eq(expected)
+    end
+  end
 end

--- a/spec/markup_fuel/library/serialize/xml_spec.rb
+++ b/spec/markup_fuel/library/serialize/xml_spec.rb
@@ -131,4 +131,69 @@ describe MarkupFuel::Library::Serialize::Xml do
       end
     end
   end
+
+  describe 'README examples' do
+    specify 'the simple writing example works' do
+      pipeline = {
+        jobs: [
+          {
+            name: 'load_patients',
+            type: 'b/value/static',
+            register: :patients,
+            value: {
+              'patient' => [
+                {
+                  'demographics' => {
+                    'first' => 'Bozo',
+                    'last' => 'Clown'
+                  },
+                  'id' => '1'
+                },
+                {
+                  'demographics' => {
+                    'first' => 'Frank',
+                    'last' => 'Rizzo'
+                  },
+                  'id' => '2'
+                }
+              ]
+            }
+          },
+          {
+            name: 'to_xml',
+            type: 'markup_fuel/serialize/xml',
+            register: :patients,
+            root_name: :patients
+          }
+        ]
+      }
+
+      payload = Burner::Payload.new
+
+      Burner::Pipeline.make(pipeline).execute(output: output, payload: payload)
+
+      actual = payload['patients']
+
+      expected = <<~XML
+        <patients>
+          <patient>
+            <demographics>
+              <first>Bozo</first>
+              <last>Clown</last>
+            </demographics>
+            <id>1</id>
+          </patient>
+          <patient>
+            <demographics>
+              <first>Frank</first>
+              <last>Rizzo</last>
+            </demographics>
+            <id>2</id>
+          </patient>
+        </patients>
+      XML
+
+      expect(actual).to eq(expected)
+    end
+  end
 end

--- a/spec/markup_fuel/library/serialize/xml_spec.rb
+++ b/spec/markup_fuel/library/serialize/xml_spec.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+#
+# Copyright (c) 2020-present, Blue Marble Payroll, LLC
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+require 'spec_helper'
+
+def bare(val)
+  val.to_s.gsub("\n", '').gsub(' ', '')
+end
+
+describe MarkupFuel::Library::Serialize::Xml do
+  let(:output)        { Burner::Output.new(outs: [StringIO.new]) }
+  let(:register)      { 'register_a' }
+  let(:no_attributes) { true }
+  let(:root_name)     { 'patients' }
+
+  let(:contents) do
+    {
+      'patient' => [
+        {
+          'demographics' => {
+            'first' => 'Bozo',
+            'last' => 'Clown'
+          },
+          'id' => '1'
+        },
+        {
+          'demographics' => {
+            'first' => 'Frank',
+            'last' => 'Rizzo'
+          },
+          'id' => '2'
+        }
+      ]
+    }
+  end
+
+  let(:payload) { Burner::Payload.new(registers: { register => contents }) }
+
+  subject do
+    described_class.make(
+      name: 'test_job',
+      no_attributes: no_attributes,
+      register: register,
+      root_name: root_name
+    )
+  end
+
+  describe '#perform' do
+    before(:each) { subject.perform(output, payload) }
+
+    context 'when root_name is blank' do
+      let(:root_name) { '' }
+
+      it 'serializes data with default root node' do
+        actual = payload[register]
+
+        expected = <<~XML
+          <opt>
+            <patient>
+              <demographics>
+                <first>Bozo</first>
+                <last>Clown</last>
+              </demographics>
+              <id>1</id>
+            </patient>
+            <patient>
+              <demographics>
+                <first>Frank</first>
+                <last>Rizzo</last>
+              </demographics>
+              <id>2</id>
+            </patient>
+          </opt>
+        XML
+
+        expect(actual).to eq(expected)
+      end
+    end
+
+    context 'when root_name is present' do
+      it 'serializes data with specified root node' do
+        actual = payload[register]
+
+        expected = <<~XML
+          <patients>
+            <patient>
+              <demographics>
+                <first>Bozo</first>
+                <last>Clown</last>
+              </demographics>
+              <id>1</id>
+            </patient>
+            <patient>
+              <demographics>
+                <first>Frank</first>
+                <last>Rizzo</last>
+              </demographics>
+              <id>2</id>
+            </patient>
+          </patients>
+        XML
+
+        expect(actual).to eq(expected)
+      end
+    end
+
+    context 'when no_attributes is false' do
+      let(:no_attributes) { false }
+
+      it 'serializes data with attributes' do
+        actual = payload[register]
+
+        expected = <<~XML
+          <patients>
+            <patient id="1">
+              <demographics first="Bozo" last="Clown" />
+            </patient>
+            <patient id="2">
+              <demographics first="Frank" last="Rizzo" />
+            </patient>
+          </patients>
+        XML
+
+        expect(actual).to eq(expected)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is the initial implementation for XML processing within the Burner pipeline.  The reason this is not shipped with Burner is due to the external libraries necessary for working with XML.  Similar to db_fuel needing active_record support, this library comes with support from [xml-simple](https://github.com/maik/xml-simple).  I found that library to be lightweight and meets the needs for XML processing given our context.  There are tons of opportunities for extending these jobs and/or providing new ones, but they are meant to provide a baseline for extension.  The reality is XML can quickly become non-trivial and the goal here is to not try and boil the ocean, but to start as simple as possible and work from there.